### PR TITLE
[DEVOPS-2] Initial counter-service app and containerization setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ GET request it gets.
 
 The service's tests and deployment is executed using Azure DevOps Pipelines
 
+## Local Setup and Test
+
+- install `docker` client
+- `docker build -f ./app/counter-service.Dockerfile -t counter-service .`
+- `docker run -p 80:80 counter-service:latest`
+- At this point, the container will run the flask app.
+- You may test the counter service functionality by executing locally:
+  - `curl localhost:80` (expected output: `Counter value: 0`)
+  - `curl -X POST localhost:80` (expected output: `This counter now increased`)
+  - `curl localhost:80` (expected output: `Counter value: 1`)
+- Now, you may exit the container by pressing `Ctrl+C`

--- a/app/counter-service.Dockerfile
+++ b/app/counter-service.Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10.8-slim-buster
+WORKDIR /counter-service
+
+COPY ./app/requirements.txt ./app/requirements.txt
+RUN pip3 install -r ./app/requirements.txt
+
+COPY ./app ./app
+
+EXPOSE 80
+
+CMD [ "python3", "./app/counter-service.py"]

--- a/app/counter-service.py
+++ b/app/counter-service.py
@@ -1,0 +1,15 @@
+#!flask/bin/python
+from flask import Flask, request, request_started
+
+app = Flask(__name__)
+counter = 0
+@app.route('/', methods=["POST", "GET"])
+def index():
+    global counter
+    if request.method == "POST":
+        counter+=1
+        return "This counter now increased"
+    else:
+        return str(f"Counter value: {counter} ")
+if __name__ == '__main__':
+    app.run(debug=True,port=80,host='0.0.0.0')

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,7 @@
+blinker==1.6.2
+click==8.1.6
+Flask==2.3.2
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+Werkzeug==2.3.6


### PR DESCRIPTION
Current limitations:
1. Supports only single container instance, meaning that the counter index is relevant only for calls that are made when a single container is started.
- In order to allow multiple container replicas, we need to have either a load balancer that could be used to mainly route the calls so all the calls could be counted and \ or to store the counters index of all of the containers at a given moment in a database, so we could sum the total amount of calls.
2. Not production ready yet since:
- It is exected in debug mode
- The docker is not yet multi-staged so the packages installations could occur separately from the execution
- The image inheritance is a general inheritance of the base image of slim python3.10 and not the exact image digest that was pulled.